### PR TITLE
Fix UnknownPacketError

### DIFF
--- a/lib/redstone_bot/protocol/packets.rb
+++ b/lib/redstone_bot/protocol/packets.rb
@@ -31,7 +31,7 @@ module RedstoneBot
 
     def self.receive(stream)
       tid = stream.read_byte
-      packet_class = types[tid] or raise UnknownPacketError, type
+      packet_class = types[tid] or raise UnknownPacketError, tid
       packet_class.receive_data(stream)
     end
 


### PR DESCRIPTION
UnknownPacketError currently raises a NameError

```
redstone-bot2/lib/redstone_bot/protocol/packets.rb:34:in `receive': undefined local variable or method `type' for RedstoneBot::Packet:Class (NameError)
```

This commit makes sure it raises the proper error

```
redstone-bot2/lib/redstone_bot/protocol/packets.rb:34:in `receive': RedstoneBot::UnknownPacketError (RedstoneBot::UnknownPacketError)
```

``type`` is a leftover from this refactor: https://github.com/DavidEGrayson/redstone-bot2/commit/ae16444bd144465b2689004257257352db02fc7f#diff-e52be86f6fe732d3e3499b7553e8e738c949e48181b12098da99cfde215a982aL48-R35